### PR TITLE
Adding endogenous DNA for Normalized Log Ratio and various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/test_data
 *.pyc
 *.ipynb_checkpoints
 docs/build/
+test/

--- a/bin/normalizedReadCount
+++ b/bin/normalizedReadCount
@@ -98,6 +98,24 @@ def get_args():
         help="Output bam 3 filename. Default = {BAM2_INPUT}.filtered.bam"
     )
     parser.add_argument(
+        '-ed1',
+        dest="endo_dna1",
+        default=0.01,
+        help="Proportion of endogenous DNA in microbiome for organism 1. Default = 0.05"
+    )
+    parser.add_argument(
+        '-ed2',
+        dest="endo_dna2",
+        default=0.01,
+        help="Proportion of endogenous DNA in microbiome for organism 2. Default = 0.05"
+    )
+    parser.add_argument(
+        '-ed3',
+        dest="endo_dna3",
+        default=0.01,
+        help="Proportion of endogenous DNA in microbiome for organism 3. Default = 0.05"
+    )
+    parser.add_argument(
         '-p',
         dest="processes",
         default=4,
@@ -121,10 +139,31 @@ def get_args():
     obam1 = args.output_bam1
     obam2 = args.output_bam2
     obam3 = args.output_bam3
+    endo1 = float(str(args.endo_dna1))
+    endo2 = float(str(args.endo_dna2))
+    endo3 = float(str(args.endo_dna3))
 
     processes = int(args.processes)
 
-    return(bam1, genome1, organame1, bam2, genome2, organame2, bam3, genome3, organame3, sname, identity, processes, outfile, obam1, obam2, obam3)
+    return(bam1,
+           genome1,
+           organame1,
+           bam2,
+           genome2,
+           organame2,
+           bam3,
+           genome3,
+           organame3,
+           sname,
+           identity,
+           processes,
+           outfile,
+           obam1,
+           obam2,
+           obam3,
+           endo1,
+           endo2,
+           endo3)
 
 
 def getBasename(file_name):
@@ -233,8 +272,16 @@ def getCommonReads(readsBam1, readsBam2, readsBam3=None):
     return(res)
 
 
+def check_endo(endo_dna, organism):
+    if endo_dna >= 0 and endo_dna <= 1:
+        return True
+    else:
+        print(f"{endo_dna} is not valid: proportion of endogenous DNA for {organism} should be between 0 and 1. ")
+        sys.exit(1)
+
+
 if __name__ == "__main__":
-    BAM1, GENOME1, ORGANAME1, BAM2, GENOME2, ORGANAME2, BAM3, GENOME3, ORGANAME3, SNAME, ID, PROCESSES, OUTFILE, OBAM1, OBAM2, OBAM3 = get_args()
+    BAM1, GENOME1, ORGANAME1, BAM2, GENOME2, ORGANAME2, BAM3, GENOME3, ORGANAME3, SNAME, ID, PROCESSES, OUTFILE, OBAM1, OBAM2, OBAM3, ENDO1, ENDO2, ENDO3 = get_args()
 
     if BAM1 is None:
         print("Missing BAM file")
@@ -245,8 +292,12 @@ if __name__ == "__main__":
 
     bam_basename1 = getBasename(BAM1)
     bam_basename2 = getBasename(BAM2)
+    check_endo(ENDO1, ORGANAME1)
+    check_endo(ENDO2, ORGANAME2)
+
     if BAM3:
         bam_basename3 = getBasename(BAM3)
+        check_endo(ENDO3, ORGANAME3)
 
     if not OUTFILE:
         OUTFILE = SNAME + ".out"
@@ -309,13 +360,13 @@ if __name__ == "__main__":
         writeBam(inbam=BAM3, outbam=outbam3, commonReads=commonReads)
 
     # Two genomes
-    NormalizedReadRatio_1 = (nnbp1 / (nnbp1 + nnbp2))
-    NormalizedReadRatio_2 = (nnbp2 / (nnbp1 + nnbp2))
+    NormalizedReadRatio_1 = (nnbp1 / (nnbp1 + nnbp2)) * ENDO1
+    NormalizedReadRatio_2 = (nnbp2 / (nnbp1 + nnbp2)) * ENDO2
     if BAM3:
         # Three genomes
-        NormalizedReadRatio_1 = (nnbp1 / (nnbp1 + nnbp2 + nnbp3))
-        NormalizedReadRatio_2 = (nnbp2 / (nnbp1 + nnbp2 + nnbp3))
-        NormalizedReadRatio_3 = (nnbp3 / (nnbp1 + nnbp2 + nnbp3))
+        NormalizedReadRatio_1 = (nnbp1 / (nnbp1 + nnbp2 + nnbp3)) * ENDO1
+        NormalizedReadRatio_2 = (nnbp2 / (nnbp1 + nnbp2 + nnbp3)) * ENDO2
+        NormalizedReadRatio_3 = (nnbp3 / (nnbp1 + nnbp2 + nnbp3)) * ENDO3
 
     # sourcepredict
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # nf-core/coproid: Documentation
 
-![logo](source/\_static/img/coproid_logo_small.jpg)
+![logo](source/_static/img/coproid_logo_small.jpg)
 
 **coproID** (**CO**prolite **ID**entification) is a tool developed at the
 [Max Planck insitute for the Science of Human History](http://www.shh.mpg.de/en)
@@ -16,14 +16,14 @@ and made available through [nf-core](https://github.com/nf-core)
 Even though it was developed with coprolite host identification in mind, it can
  be applied to any microbiome, provided they contain host DNA.
 
-1. [Installation](https://nf-co.re/usage/installation)
-2. Pipeline configuration
-    - [Local installation](https://nf-co.re/usage/local_installation)
-    - [Adding your own system config](https://nf-co.re/usage/adding_own_config)
-    - [Reference genomes](https://nf-co.re/usage/reference_genomes)
-3. [Running the pipeline](usage.md)
-4. [Output and how to interpret the results](output.md)
-5. [Troubleshooting](https://nf-co.re/usage/troubleshooting)
+1.  [Installation](https://nf-co.re/usage/installation)
+2.  Pipeline configuration
+    -   [Local installation](https://nf-co.re/usage/local_installation)
+    -   [Adding your own system config](https://nf-co.re/usage/adding_own_config)
+    -   [Reference genomes](https://nf-co.re/usage/reference_genomes)
+3.  [Running the pipeline](usage.md)
+4.  [Output and how to interpret the results](output.md)
+5.  [Troubleshooting](https://nf-co.re/usage/troubleshooting)
 
 ## Quick start
 
@@ -34,63 +34,57 @@ Example:
 ## coproID help menu
 
     $ nextflow run nf-core/coproid --help
-    N E X T F L O W  ~  version 19.01.0
-    Launching `./main.nf` [nasty_ride] - revision: 362ad5aeaf
-    ----------------------------------------------------
-                                            ,--./,-.
-            ___     __   __   __   ___     /,-._.--~'
-      |\ | |__  __ /  ` /  \ |__) |__         }  {
-      | \| |       \__, \__/ |  \ |___     \`-._,-`-,
-                                            `._,._,'
-      nf-core/coproid v1.0dev
-    ----------------------------------------------------
+    coproID: Coprolite Identification
+     Homepage: <https://github.com/nf-core/coproid>
+     Author: Maxime Borry <mailto:borry@shh.mpg.de>
 
+    # Version 1.0dev
 
-     coproID: Coprolite Identification
-     Homepage: https://github.com/nf-core/coproid
-     Author: Maxime Borry <borry@shh.mpg.de>
-     Version 1.0dev
-    =========================================
     Usage:
     The typical command for running the pipeline is as follows:
-    nextflow run maxibor/coproid --genome1 'GRCh37' --genome2 'CanFam3.1' --name1 'Homo_sapiens' --name2 'Canis_familiaris' --reads '*_R{1,2}.fastq.gz'
+    nextflow run maxibor/coproid --genome1 'GRCh37' --genome2 'CanFam3.1' --name1 'Homo_sapiens' --name2 'Canis_familiaris' --reads '\*\_R{1,2}.fastq.gz'
     Mandatory arguments:
-      --reads                       Path to input data (must be surrounded with quotes)
-      --name1                       Name of candidate 1. Example: "Homo_sapiens"
-      --fasta1                      Path to human genome fasta file (must be surrounded with quotes). Must be provided if --genome1 is not provided
-      --genome1                     Name of iGenomes reference for Homo_sapiens. Must be provided if --fasta1 is not provided
-      --name2                       Name of candidate 2. Example: "Canis_familiaris"
-      --fasta2                      Path to canidate organism 2 genome fasta file (must be surrounded with quotes). Must be provided if --genome2 is not provided
-      --genome2                     Name of iGenomes reference for candidate organism 2. Must be provided if --fasta2 is not provided
-      --krakendb                    Path to MiniKraken2_v2_8GB Database
+      \--reads                       Path to input data (must be surrounded with quotes)
+      \--name1                       Name of candidate 1. Example: "Homo_sapiens"
+      \--fasta1                      Path to human genome fasta file (must be surrounded with quotes). Must be provided if --genome1 is not provided
+      \--genome1                     Name of iGenomes reference for Homo_sapiens. Must be provided if --fasta1 is not provided
+      \--name2                       Name of candidate 2. Example: "Canis_familiaris"
+      \--fasta2                      Path to canidate organism 2 genome fasta file (must be surrounded with quotes). Must be provided if --genome2 is not provided
+      \--genome2                     Name of iGenomes reference for candidate organism 2. Must be provided if --fasta2 is not provided
+      \--krakendb                    Path to MiniKraken2_v2_8GB Database
+
+    Settings:
+      \--adna                        Specified if data is modern (false) or ancient DNA (true). Default = true
+      \--phred                       Specifies the fastq quality encoding (33 | 64). Defaults to 33
+      \--singleEnd                   Specified if reads are single-end (true | false). Default = false
+      \--collapse                    Specifies if AdapterRemoval should merge the paired-end sequences or not (true | false). Default = true
+      \--identity                    Identity threshold to retain read alignment. Default = 0.95
+      \--pmdscore                    Minimum PMDscore to retain read alignment. Default = 3
+      \--library                     DNA preparation library type ( classic | UDGhalf). Default = classic
+      \--bowtie                      Bowtie settings for sensivity (very-fast | very-sensitive). Default = very-sensitive
+      \--minKraken                   Minimum number of Kraken hits per Taxonomy ID to report. Default = 50
+      \--endo1                       Proportion of Endogenous DNA in organism 1 target microbiome
+      \--endo2                       Proportion of Endogenous DNA in organism 2 target microbiome
+      \--endo3                       Proportion of Endogenous DNA in organism 3 target microbiome
 
     Options:
-      --name3                       Name of candidate 1. Example: "Sus_scrofa"
-      --fasta3                      Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if --genome3 is not provided
-      --genome3                     Name of iGenomes reference for candidate organism 3. Must be provided if --fasta3 is not provided
-      --adna                        Specified if data is modern (false) or ancient DNA (true). Default = true
-      --phred                       Specifies the fastq quality encoding (33 | 64). Defaults to 33
-      --singleEnd                   Specified if reads are single-end (true | false). Default = false
-      --index1                      Path to Bowtie2 index of genome candidate 1, in the form of "/path/to/bowtie_index/basename"
-      --index2                      Path to Bowtie2 index genome candidate 2 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
-      --index3                      Path to Bowtie2 index genome candidate 3 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
-      --collapse                    Specifies if AdapterRemoval should merge the paired-end sequences or not (true | false). Default = true
-      --identity                    Identity threshold to retain read alignment. Default = 0.95
-      --pmdscore                    Minimum PMDscore to retain read alignment. Default = 3
-      --library                     DNA preparation library type ( classic | UDGhalf). Default = classic
-      --bowtie                      Bowtie settings for sensivity (very-fast | very-sensitive). Default = very-sensitive
-      --minKraken                   Minimum number of Kraken hits per Taxonomy ID to report. Default = 50
+      \--name3                       Name of candidate 1. Example: "Sus_scrofa"
+      \--fasta3                      Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if --genome3 is not provided
+      \--genome3                     Name of iGenomes reference for candidate organism 3. Must be provided if --fasta3 is not provided
+      \--index1                      Path to Bowtie2 index of genome candidate 1, in the form of "/path/to/bowtie_index/basename"
+      \--index2                      Path to Bowtie2 index genome candidate 2 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
+      \--index3                      Path to Bowtie2 index genome candidate 3 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
 
      Other options:
-      --outdir                      The output directory where the results will be saved. Defaults to ./results
-      --email                       Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits
-      --maxMultiqcEmailFileSize     Theshold size for MultiQC report to be attached in notification email. If file generated by pipeline exceeds the threshold, it will not be attached (Default: 25MB)
-      -name                         Name for the pipeline run. If not specified, Nextflow will automatically generate a random mnemonic.
-      --help  --h                   Shows this help page
+      \--outdir                      The output directory where the results will be saved. Defaults to ./results
+      \--email                       Set this parameter to your e-mail address to get a summary e-mail with details of the run sent to you when the workflow exits
+      \--maxMultiqcEmailFileSize     Theshold size for MultiQC report to be attached in notification email. If file generated by pipeline exceeds the threshold, it will not be attached (Default: 25MB)
+      \-name                         Name for the pipeline run. If not specified, Nextflow will automatically generate a random mnemonic.
+      \--help  --h                   Shows this help page
 
 ## coproID example workFlow
 
-![dag](_static/img/coproid_dag.png)
+![dag](source/_static/img/coproid_dag.png)
 
 ## How to cite coproID
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -53,20 +53,20 @@ Use this parameter to choose a configuration profile. Profiles can give configur
 
 If `-profile` is not specified at all the pipeline will be run locally and expects all software to be installed and available on the `PATH`.
 
-- `awsbatch`
-  - A generic configuration profile to be used with AWS Batch.
-- `conda`
-  - A generic configuration profile to be used with [conda](https://conda.io/docs/)
-  - Pulls most software from [Bioconda](https://bioconda.github.io/)
-- `docker`
-  - A generic configuration profile to be used with [Docker](http://docker.com/)
-  - Pulls software from dockerhub: [`nfcore/coproid`](http://hub.docker.com/r/nfcore/coproid/)
-- `singularity`
-  - A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
-  - Pulls software from DockerHub: [`nfcore/coproid`](http://hub.docker.com/r/nfcore/coproid/)
-- `test`
-  - A profile with a complete configuration for automated testing
-  - Includes links to test data so needs no other parameters
+-   `awsbatch`
+    -   A generic configuration profile to be used with AWS Batch.
+-   `conda`
+    -   A generic configuration profile to be used with [conda](https://conda.io/docs/)
+    -   Pulls most software from [Bioconda](https://bioconda.github.io/)
+-   `docker`
+    -   A generic configuration profile to be used with [Docker](http://docker.com/)
+    -   Pulls software from dockerhub: [`nfcore/coproid`](http://hub.docker.com/r/nfcore/coproid/)
+-   `singularity`
+    -   A generic configuration profile to be used with [Singularity](http://singularity.lbl.gov/)
+    -   Pulls software from DockerHub: [`nfcore/coproid`](http://hub.docker.com/r/nfcore/coproid/)
+-   `test`
+    -   A profile with a complete configuration for automated testing
+    -   Includes links to test data so needs no other parameters
 
 ### `--reads`
 
@@ -78,9 +78,9 @@ Use this to specify the location of your input FastQ files. For example:
 
 Please note the following requirements:
 
-1. The path must be enclosed in quotes
-2. The path must have at least one `*` wildcard character
-3. When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.
+1.  The path must be enclosed in quotes
+2.  The path must have at least one `*` wildcard character
+3.  When using the pipeline with paired end data, the path must use `{1,2}` notation to specify read pairs.
 
 If left unspecified, a default pattern is used: `data/*{1,2}.fastq.gz`
 
@@ -116,10 +116,10 @@ There are 31 different species supported in the iGenomes references. To run the 
 
 You can find the keys to specify the genomes in the [iGenomes config file](../conf/igenomes.config). Common genomes that are supported are:
 
-- Human
-  - `--genome GRCh37`
-- Dog
-  - `--genome CanFam3.1`
+-   Human
+    -   `--genome GRCh37`
+-   Dog
+    -   `--genome CanFam3.1`
 
 > There are numerous others - check the config file for more.
 
@@ -203,35 +203,7 @@ Name of iGenomes reference for candidate organism 3. Must be provided if fasta2 
 
 Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`.
 
-## Other parameters
-
-### `--name3`
-
-Name of candidate 1. Example: "Sus_scrofa"
-
-### `--fasta3`
-
-Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if ### \`genome3 is not provided
-
-```bash
---fasta3 'path/to/fasta/reference.fa'
-```
-
-### `--genome3`
-
-Name of iGenomes reference for candidate organism 3. Must be provided if \`fasta3 is not provided
-
-```bash
---genome3 'Sscrofa10.2'
-```
-
-### `--krakendb`
-
-Path to MiniKraken2_v2_8GB Database
-
-```bash
---krakendb /path/to/krakendb
-```
+## Settings
 
 ### `--adna`
 
@@ -259,30 +231,6 @@ or
 
 ```bash
 --phred 64
-```
-
-### `--index1`
-
-Path to Bowtie2 index genome candidate 2 Coprolite maker's genome
-
-```bash
---index1 'path/to/bt_index/basename*'
-```
-
-### `--index2`
-
-Path to Bowtie2 index genome candidate 2 Coprolite maker's genome
-
-```bash
---index2 'path/to/bt_index/basename*'
-```
-
-### `--index3`
-
-Path to Bowtie2 index genome candidate 3 Coprolite maker's genome
-
-```bash
---index3 'path/to/bt_index/basename*'
 ```
 
 ### `--collapse`
@@ -349,6 +297,84 @@ Minimum number of Kraken hits per Taxonomy ID to report. Default = 50
 
 ```bash
 --minKraken 50
+```
+
+### `--endo1`
+
+Proportion of Endogenous DNA in organism 1 target microbiome. Must be between 0 and 1. Default = 0.01
+
+```bash
+--endo1 0.01
+```
+
+### `--endo2`
+
+Proportion of Endogenous DNA in organism 2 target microbiome. Must be between 0 and 1. Default = 0.01
+
+```bash
+--endo2 0.01
+```
+
+### `--endo3`
+
+Proportion of Endogenous DNA in organism 3 target microbiome. Must be between 0 and 1. Default = 0.01
+
+```bash
+--endo3 0.01
+```
+
+## Other parameters
+
+### `--name3`
+
+Name of candidate 1. Example: "Sus_scrofa"
+
+### `--fasta3`
+
+Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if ### \`genome3 is not provided
+
+```bash
+--fasta3 'path/to/fasta/reference.fa'
+```
+
+### `--genome3`
+
+Name of iGenomes reference for candidate organism 3. Must be provided if \`fasta3 is not provided
+
+```bash
+--genome3 'Sscrofa10.2'
+```
+
+### `--krakendb`
+
+Path to MiniKraken2_v2_8GB Database
+
+```bash
+--krakendb /path/to/krakendb
+```
+
+### `--index1`
+
+Path to Bowtie2 index genome candidate 2 Coprolite maker's genome
+
+```bash
+--index1 'path/to/bt_index/basename*'
+```
+
+### `--index2`
+
+Path to Bowtie2 index genome candidate 2 Coprolite maker's genome
+
+```bash
+--index2 'path/to/bt_index/basename*'
+```
+
+### `--index3`
+
+Path to Bowtie2 index genome candidate 3 Coprolite maker's genome
+
+```bash
+--index3 'path/to/bt_index/basename*'
 ```
 
 ## Job resources

--- a/main.nf
+++ b/main.nf
@@ -138,6 +138,7 @@ if (bt1) {
     Channel
         .fromPath(bt1_dir+"/*.bt2")
         .ifEmpty {exit 1, "Cannot find any index matching : ${bt1}\n"}
+        .collect()
         .set {bt1_ch}
 } else {
     bt1_index = params.name1
@@ -166,6 +167,7 @@ if (bt2) {
     Channel
         .fromPath(bt2_dir+"/*.bt2")
         .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt2}\n"}
+        .collect()
         .set {bt2_ch}
 
 } else {
@@ -194,6 +196,7 @@ if (params.name3) {
         Channel
             .fromPath(bt3_dir+"/*.bt2")
             .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt3}\n"}
+            .collect()
             .set {bt3_ch}
     } else {
         bt3_index = params.name3

--- a/main.nf
+++ b/main.nf
@@ -47,9 +47,9 @@ def helpMessage() {
       --library                     DNA preparation library type ( classic | UDGhalf). Default = ${params.library}
       --bowtie                      Bowtie settings for sensivity (very-fast | very-sensitive). Default = ${params.bowtie}
       --minKraken                   Minimum number of Kraken hits per Taxonomy ID to report. Default = ${params.minKraken}
-      --endo1                       Proportion of Endogenous DNA in organism 1 microbiome
-      --endo2                       Proportion of Endogenous DNA in organism 2 microbiome
-      --endo3                       Proportion of Endogenous DNA in organism 3 microbiome
+      --endo1                       Proportion of Endogenous DNA in organism 1 target microbiome
+      --endo2                       Proportion of Endogenous DNA in organism 2 target microbiome
+      --endo3                       Proportion of Endogenous DNA in organism 3 target microbiome
 
     Options:
       --name3                       Name of candidate 1. Example: "Sus_scrofa"

--- a/main.nf
+++ b/main.nf
@@ -564,7 +564,7 @@ process AlignToGenome1 {
         outfile = name+"_"+params.name1+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name1+".unaligned.sorted.bam"
         if (params.index1){
-            bt1_index = "${bt1_dir}/${bt1_index}"
+            bt1_index = "${index.toString()}/${bt1_index}"
         }
         if (params.collapse == true || params.singleEnd == true) {
             """
@@ -668,7 +668,7 @@ process AlignToGenome2 {
         outfile = name+"_"+params.name2+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name2+".unaligned.sorted.bam"
         if (params.index2){
-            bt2_index = "${bt2_dir}/${bt2_index}"
+            bt2_index = "${index.toString()}/${bt2_index}"
         }
         if (params.collapse == true || params.singleEnd == true) {
             """
@@ -708,7 +708,7 @@ if (params.name3) {
             outfile = name+"_"+params.name3+".aligned.sorted.bam"
             outfile_unalign = name+"_"+params.name3+".unaligned.sorted.bam"
             if (params.index3){
-                bt3_index = "${bt3_dir}/${bt3_index}"
+                bt3_index = "${index.toString()}/${bt3_index}"
             }
             if (params.collapse == true || params.singleEnd == true) {
                 """

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ if (bt1) {
     bt1_index = bt1.substring(lastPath+1)
 
     Channel
-        .fromPath(bt1_dir)
+        .fromPath(bt1_dir+"/*.bt2")
         .ifEmpty {exit 1, "Cannot find any index matching : ${bt1}\n"}
         .set {bt1_ch}
 } else {
@@ -164,7 +164,7 @@ if (bt2) {
     bt2_index = bt2.substring(lastPath+1)
 
     Channel
-        .fromPath(bt2_dir)
+        .fromPath(bt2_dir+"/*.bt2")
         .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt2}\n"}
         .set {bt2_ch}
 
@@ -192,7 +192,7 @@ if (params.name3) {
         bt3_index = bt3.substring(lastPath+1)
 
         Channel
-            .fromPath(bt3_dir)
+            .fromPath(bt3_dir+"/*.bt2")
             .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt3}\n"}
             .set {bt3_ch}
     } else {
@@ -563,21 +563,14 @@ process AlignToGenome1 {
         fstat = name+"_"+params.name1+".stats.txt"
         outfile = name+"_"+params.name1+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name1+".unaligned.sorted.bam"
-        if (params.index1){
-            bt_preprocess = "cp ${index.toString()}/*.bt2 ."
-        } else {
-            bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
-        }
         if (params.collapse == true || params.singleEnd == true) {
             """
-            $bt_preprocess
             bowtie2 -x $bt1_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
             """
         } else if (params.collapse == false){
             """
-            $bt_preprocess
             bowtie2 -x $bt1_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
@@ -671,21 +664,14 @@ process AlignToGenome2 {
         fstat = name+"_"+params.name2+".stats.txt"
         outfile = name+"_"+params.name2+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name2+".unaligned.sorted.bam"
-        if (params.index2){
-            bt_preprocess = "cp ${index.toString()}/*.bt2 ."
-        } else {
-            bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
-        }
         if (params.collapse == true || params.singleEnd == true) {
             """
-            $bt_preprocess
             bowtie2 -x $bt2_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
             """
         } else if (params.collapse == false){
             """
-            $bt_preprocess
             bowtie2 -x $bt2_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
@@ -715,21 +701,14 @@ if (params.name3) {
             fstat = name+"_"+params.name3+".stats.txt"
             outfile = name+"_"+params.name3+".aligned.sorted.bam"
             outfile_unalign = name+"_"+params.name3+".unaligned.sorted.bam"
-            if (params.index3){
-                bt_preprocess = "cp ${index.toString()}/*.bt2 ."
-            }else {
-                bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
-            }
             if (params.collapse == true || params.singleEnd == true) {
                 """
-                $bt_preprocess
                 bowtie2 -x $bt3_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
                 samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
                 samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
                 """
             } else if (params.collapse == false){
                 """
-                $bt_preprocess
                 bowtie2 -x $bt3_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
                 samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
                 samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign

--- a/main.nf
+++ b/main.nf
@@ -26,7 +26,7 @@ def helpMessage() {
     =========================================
     Usage:
     The typical command for running the pipeline is as follows:
-    nextflow run maxibor/coproid --genome1 'GRCh37' --genome2 'CanFam3.1' --name1 'Homo_sapiens' --name2 'Canis_familiaris' --reads '*_R{1,2}.fastq.gz'
+    nextflow run maxibor/coproid -profile docker --genome1 'GRCh37' --genome2 'CanFam3.1' --name1 'Homo_sapiens' --name2 'Canis_familiaris' --reads '*_R{1,2}.fastq.gz'
     Mandatory arguments:
       --reads                       Path to input data (must be surrounded with quotes)
       --name1                       Name of candidate 1. Example: "Homo_sapiens"
@@ -85,6 +85,18 @@ report_template = "$baseDir/templates/coproID_report.ipynb"
 // Show help message
 if (params.help){
     helpMessage()
+    exit 0
+}
+
+// Message for empty run
+if (!params.reads || !params.name1 || !params.name2 || !params.krakendb){
+    log.info"""
+    CoproID was launched with missing mandatory arguments.
+    Please check your command line and retry.
+    To get the help menu, please run:
+    nextflow run maxibor/coproid --help
+    The complete documentation is available at https://github.com/nf-core/coproid
+    """
     exit 0
 }
 

--- a/main.nf
+++ b/main.nf
@@ -47,9 +47,9 @@ def helpMessage() {
       --library                     DNA preparation library type ( classic | UDGhalf). Default = ${params.library}
       --bowtie                      Bowtie settings for sensivity (very-fast | very-sensitive). Default = ${params.bowtie}
       --minKraken                   Minimum number of Kraken hits per Taxonomy ID to report. Default = ${params.minKraken}
-      --endo1                       Proportion of Endogenous DNA in organism 1 target microbiome
-      --endo2                       Proportion of Endogenous DNA in organism 2 target microbiome
-      --endo3                       Proportion of Endogenous DNA in organism 3 target microbiome
+      --endo1                       Proportion of Endogenous DNA in organism 1 target microbiome. Default = ${params.endo1}
+      --endo2                       Proportion of Endogenous DNA in organism 2 target microbiome. Default = ${params.endo1}
+      --endo3                       Proportion of Endogenous DNA in organism 3 target microbiome. Default = ${params.endo1}
 
     Options:
       --name3                       Name of candidate 1. Example: "Sus_scrofa"
@@ -79,6 +79,7 @@ DEFAULT VARIABLE VALUES SETUP
 bowtie_setting = ''
 collapse_setting = ''
 multiqc_conf = "$baseDir/conf/.multiqc_config.yaml"
+report_template = "$baseDir/templates/coproID_report.ipynb"
 
 
 // Show help message

--- a/main.nf
+++ b/main.nf
@@ -37,22 +37,27 @@ def helpMessage() {
       --genome2                     Name of iGenomes reference for candidate organism 2. Must be provided if --fasta2 is not provided
       --krakendb                    Path to MiniKraken2_v2_8GB Database
 
-    Options:
-      --name3                       Name of candidate 1. Example: "Sus_scrofa"
-      --fasta3                      Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if --genome3 is not provided
-      --genome3                     Name of iGenomes reference for candidate organism 3. Must be provided if --fasta3 is not provided
+    Settings:
       --adna                        Specified if data is modern (false) or ancient DNA (true). Default = ${params.adna}
       --phred                       Specifies the fastq quality encoding (33 | 64). Defaults to ${params.phred}
       --singleEnd                   Specified if reads are single-end (true | false). Default = ${params.singleEnd}
-      --index1                      Path to Bowtie2 index of genome candidate 1, in the form of "/path/to/bowtie_index/basename"
-      --index2                      Path to Bowtie2 index genome candidate 2 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
-      --index3                      Path to Bowtie2 index genome candidate 3 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
       --collapse                    Specifies if AdapterRemoval should merge the paired-end sequences or not (true | false). Default = ${params.collapse}
       --identity                    Identity threshold to retain read alignment. Default = ${params.identity}
       --pmdscore                    Minimum PMDscore to retain read alignment. Default = ${params.pmdscore}
       --library                     DNA preparation library type ( classic | UDGhalf). Default = ${params.library}
       --bowtie                      Bowtie settings for sensivity (very-fast | very-sensitive). Default = ${params.bowtie}
       --minKraken                   Minimum number of Kraken hits per Taxonomy ID to report. Default = ${params.minKraken}
+      --endo1                       Proportion of Endogenous DNA in organism 1 microbiome
+      --endo2                       Proportion of Endogenous DNA in organism 2 microbiome
+      --endo3                       Proportion of Endogenous DNA in organism 3 microbiome
+
+    Options:
+      --name3                       Name of candidate 1. Example: "Sus_scrofa"
+      --fasta3                      Path to canidate organism 3 genome fasta file (must be surrounded with quotes). Must be provided if --genome3 is not provided
+      --genome3                     Name of iGenomes reference for candidate organism 3. Must be provided if --fasta3 is not provided
+      --index1                      Path to Bowtie2 index of genome candidate 1, in the form of "/path/to/bowtie_index/basename"
+      --index2                      Path to Bowtie2 index genome candidate 2 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
+      --index3                      Path to Bowtie2 index genome candidate 3 Coprolite maker's genome, in the form of "/path/to/bowtie_index/basename"
 
      Other options:
       --outdir                      The output directory where the results will be saved. Defaults to ${params.outdir}
@@ -96,7 +101,9 @@ params.library = 'classic'
 params.bowtie = 'very-sensitive'
 params.krakendb =''
 params.minKraken = 50
-params.removeHuman = false
+params.endo1 = 0.01
+params.endo2 = 0.01
+params.endo3 = 0.01
 
 report_template = "$baseDir/templates/coproID_report.ipynb"
 params.sp_labels = "$baseDir/data/sourcepredict/modern_gut_microbiomes_labels.csv"
@@ -471,7 +478,20 @@ if (params.collapse == true && params.singleEnd == false){
             col_out = name+".trimmed.fastq"
             settings = name+".settings"
             """
-            AdapterRemoval --basename $name --file1 ${reads[0]} --file2 ${reads[1]} --trimns --trimqualities --collapse --minquality 20 --minlength 30 --output1 $out1 --output2 $out2 --outputcollapsed $col_out --threads ${task.cpus} --qualitybase ${params.phred} --settings $settings
+            AdapterRemoval --basename $name \
+                           --file1 ${reads[0]} \
+                           --file2 ${reads[1]} \
+                           --trimns \
+                           --trimqualities \
+                           --collapse \
+                           --minquality 20 \
+                           --minlength 30 \
+                           --output1 $out1 \
+                           --output2 $out2 \
+                           --outputcollapsed $col_out \
+                           --threads ${task.cpus} \
+                           --qualitybase ${params.phred} \
+                           --settings $settings
             """
     }
 } else if (params.collapse == false || params.singleEnd == true) {
@@ -494,11 +514,31 @@ if (params.collapse == true && params.singleEnd == false){
             settings = name+".settings"
             if (params.singleEnd == false) {
                 """
-                AdapterRemoval --basename $name --file1 ${reads[0]} --file2 ${reads[1]} --trimns --trimqualities --minquality 20 --minlength 30 --output1 $out1 --output2 $out2 --threads ${task.cpus} --qualitybase ${params.phred} --settings $settings
+                AdapterRemoval --basename $name \
+                               --file1 ${reads[0]} \
+                               --file2 ${reads[1]} \
+                               --trimns \
+                               --trimqualities \
+                               --minquality 20 \
+                               --minlength 30 \
+                               --output1 $out1 \
+                               --output2 $out2 \
+                               --threads ${task.cpus} \
+                               --qualitybase ${params.phred} \
+                               --settings $settings
                 """
             } else {
                 """
-                AdapterRemoval --basename $name --file1 ${reads[0]} --trimns --trimqualities --minquality 20 --minlength 30 --output1 $se_out --threads ${task.cpus} --qualitybase ${params.phred} --settings $settings
+                AdapterRemoval --basename $name \
+                               --file1 ${reads[0]} \
+                               --trimns \
+                               --trimqualities \
+                               --minquality 20 \
+                               --minlength 30 \
+                               --output1 $se_out \
+                               --threads ${task.cpus} \
+                               --qualitybase ${params.phred} \
+                               --settings $settings
                 """
             }
             
@@ -779,11 +819,18 @@ process kraken2 {
         kreport = name+".kreport"
         if (pairedEnd && params.collapse == false){
             """
-            kraken2 --db ${krakendb} --threads ${task.cpus} --output $out --report $kreport --paired ${reads[0]} ${reads[1]}
+            kraken2 --db ${krakendb} \
+                    --threads ${task.cpus} \
+                    --output $out \
+                    --report $kreport \
+                    --paired ${reads[0]} ${reads[1]}
             """    
         } else {
             """
-            kraken2 --db ${krakendb} --threads ${task.cpus} --output $out --report $kreport ${reads[0]}
+            kraken2 --db ${krakendb} \
+                    --threads ${task.cpus} \
+                    --output $out \
+                    --report $kreport ${reads[0]}
             """
         }
         
@@ -842,7 +889,13 @@ process sourcepredict {
         outfile = "prediction.sourcepredict.csv"
         embed_out = "sourcepredict_embedding.csv"
         """
-        sourcepredict -di ${params.sp_dim} -k ${params.sp_kfold} -l ${sp_labels} -s ${sp_sources} -t ${task.cpus} -o $outfile -e $embed_out $otu_table 
+        sourcepredict -di ${params.sp_dim} \
+                      -k ${params.sp_kfold} \
+                      -l ${sp_labels} \
+                      -s ${sp_sources} \
+                      -t ${task.cpus} \
+                      -o $outfile \
+                      -e $embed_out $otu_table 
         """
 }
 
@@ -872,7 +925,20 @@ if (params.name3 == ''){
         """
         samtools index $bam1
         samtools index $bam2
-        normalizedReadCount -n $name -b1 $bam1 -b2 $bam2 -g1 $genome1 -g2 $genome2 -r1 $organame1 -r2 $organame2 -i ${params.identity} -o $outfile -ob1 $obam1 -ob2 $obam2 -p ${task.cpus}
+        normalizedReadCount -n $name \
+                            -b1 $bam1 \
+                            -b2 $bam2 \
+                            -g1 $genome1 \
+                            -g2 $genome2 \
+                            -r1 $organame1 \
+                            -r2 $organame2 \
+                            -i ${params.identity} \
+                            -o $outfile \
+                            -ob1 $obam1 \
+                            -ob2 $obam2 \
+                            -ed1 ${params.endo1} \
+                            -ed2 ${params.endo2} \
+                            -p ${task.cpus}
         """
     }
 } else {
@@ -906,7 +972,25 @@ if (params.name3 == ''){
         samtools index $bam1
         samtools index $bam2
         samtools index $bam3
-        normalizedReadCount -n $name -b1 $bam1 -b2 $bam2 -b3 $bam3 -g1 $genome1 -g2 $genome2 -g3 $genome3 -r1 $organame1 -r2 $organame2 -r3 $organame3 -i ${params.identity} -o $outfile -ob1 $obam1 -ob2 $obam2 -ob3 $obam3 -p ${task.cpus}
+        normalizedReadCount -n $name \
+                            -b1 $bam1 \
+                            -b2 $bam2 \
+                            -b3 $bam3 \
+                            -g1 $genome1 \
+                            -g2 $genome2 \
+                            -g3 $genome3 \
+                            -r1 $organame1 \
+                            -r2 $organame2 \
+                            -r3 $organame3 \
+                            -i ${params.identity} \
+                            -o $outfile \
+                            -ob1 $obam1 \
+                            -ob2 $obam2 \
+                            -ob3 $obam3 \
+                            -ed1 ${params.endo1} \
+                            -ed2 ${params.endo2} \
+                            -ed3 ${params.endo3} \
+                            -p ${task.cpus}
         """
     }
 }
@@ -1048,7 +1132,14 @@ if (params.adna) {
             script:
                 """
                 echo ${workflow.manifest.version} > version.txt
-                jupyter nbconvert --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' --TemplateExporter.exclude_input_prompt=True --TemplateExporter.exclude_output_prompt=True --ExecutePreprocessor.timeout=200 --execute --to html $report
+                jupyter nbconvert \
+                        --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' \
+                        --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' \
+                        --TemplateExporter.exclude_input_prompt=True \
+                        --TemplateExporter.exclude_output_prompt=True \
+                        --ExecutePreprocessor.timeout=200 \
+                        --execute \
+                        --to html $report
                 """
         }
     } else {
@@ -1069,7 +1160,14 @@ if (params.adna) {
             script:
                 """
                 echo ${workflow.manifest.version} > version.txt
-                jupyter nbconvert --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' --TemplateExporter.exclude_input_prompt=True --TemplateExporter.exclude_output_prompt=True --ExecutePreprocessor.timeout=200 --execute --to html $report
+                jupyter nbconvert \
+                        --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' \
+                        --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' \
+                        --TemplateExporter.exclude_input_prompt=True \
+                        --TemplateExporter.exclude_output_prompt=True \
+                        --ExecutePreprocessor.timeout=200 \
+                        --execute \
+                        --to html $report
                 """
         }
     }
@@ -1089,7 +1187,14 @@ if (params.adna) {
         script:
             """
             echo ${workflow.manifest.version} > version.txt
-            jupyter nbconvert --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' --TemplateExporter.exclude_input_prompt=True --TemplateExporter.exclude_output_prompt=True --ExecutePreprocessor.timeout=200 --execute --to html $report
+            jupyter nbconvert \
+                    --TagRemovePreprocessor.remove_input_tags='{"remove_cell"}' \
+                    --TagRemovePreprocessor.remove_all_outputs_tags='{"remove_output"}' \
+                    --TemplateExporter.exclude_input_prompt=True \
+                    --TemplateExporter.exclude_output_prompt=True \
+                    --ExecutePreprocessor.timeout=200 \
+                    --execute \
+                    --to html $report
             """
     }
 } 

--- a/main.nf
+++ b/main.nf
@@ -76,42 +76,6 @@ DEFAULT VARIABLE VALUES SETUP
 
 // Default variable configuration
 
-params.phred = 33
-
-params.adna = true
-params.outdir = "./results"
-params.reads = ''
-params.singleEnd = false
-params.genome1 = 'GRCh37'
-params.genome2 = 'CanFam3.1'
-params.genome3 = ''
-params.name1 = 'Homo_sapiens'
-params.name2 = 'Canis_familiaris'
-params.name3 = ''
-params.index1 = ''
-params.index2 = ''
-params.index3 = ''
-params.fasta1 = ''
-params.fasta2 = ''
-params.fasta3 = ''
-params.collapse = true
-params.identity = 0.95
-params.pmdscore = 3
-params.library = 'classic'
-params.bowtie = 'very-sensitive'
-params.krakendb =''
-params.minKraken = 50
-params.endo1 = 0.01
-params.endo2 = 0.01
-params.endo3 = 0.01
-
-report_template = "$baseDir/templates/coproID_report.ipynb"
-params.sp_labels = "$baseDir/data/sourcepredict/modern_gut_microbiomes_labels.csv"
-params.sp_sources = "$baseDir/data/sourcepredict/modern_gut_microbiomes_sources.csv"
-params.sp_kfold = 5
-params.sp_pdim = 20
-params.sp_dim = 2
-
 bowtie_setting = ''
 collapse_setting = ''
 multiqc_conf = "$baseDir/conf/.multiqc_config.yaml"

--- a/main.nf
+++ b/main.nf
@@ -296,17 +296,14 @@ if (params.krakendb.endsWith(".tar.gz")){
         input:
             file(ckdb) from comp_kraken
         output:
-            file("kraken") into krakendb
+            file("kraken") into krakendb_ch
         script:
             """
             tar xvzf $ckdb
             """
     }
 } else {
-    Channel
-        .from(params.krakendb)
-        .ifEmpty { exit 1, "Cannot find any Kraken DB Index at ${params.krakendb}"}
-        .set {krakendb}
+    krakendb_ch = file(params.krakendb)
 }
 
 /*******************************
@@ -787,7 +784,7 @@ process kraken2 {
 
     input:
         set val(name), file(reads) from unmapped_humans_reads
-        file(krakendb) from krakendb
+        file(krakendb) from krakendb_ch
 
 
     output:

--- a/main.nf
+++ b/main.nf
@@ -136,7 +136,7 @@ if (bt1) {
     bt1_index = bt1.substring(lastPath+1)
 
     Channel
-        .fromPath(bt1)
+        .fromPath(bt1_dir)
         .ifEmpty {exit 1, "Cannot find any index matching : ${bt1}\n"}
         .set {bt1_ch}
 } else {
@@ -164,7 +164,7 @@ if (bt2) {
     bt2_index = bt2.substring(lastPath+1)
 
     Channel
-        .fromPath(bt2)
+        .fromPath(bt2_dir)
         .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt2}\n"}
         .set {bt2_ch}
 
@@ -192,7 +192,7 @@ if (params.name3) {
         bt3_index = bt3.substring(lastPath+1)
 
         Channel
-            .fromPath(bt3)
+            .fromPath(bt3_dir)
             .ifEmpty {exit 1, "Cannot find any index matching : ${params.bt3}\n"}
             .set {bt3_ch}
     } else {

--- a/main.nf
+++ b/main.nf
@@ -564,16 +564,20 @@ process AlignToGenome1 {
         outfile = name+"_"+params.name1+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name1+".unaligned.sorted.bam"
         if (params.index1){
-            bt1_index = "${index.toString()}/${bt1_index}"
+            bt_preprocess = "cp ${index.toString()}/*.bt2 ."
+        } else {
+            bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
         }
         if (params.collapse == true || params.singleEnd == true) {
             """
+            $bt_preprocess
             bowtie2 -x $bt1_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
             """
         } else if (params.collapse == false){
             """
+            $bt_preprocess
             bowtie2 -x $bt1_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
@@ -668,16 +672,20 @@ process AlignToGenome2 {
         outfile = name+"_"+params.name2+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name2+".unaligned.sorted.bam"
         if (params.index2){
-            bt2_index = "${index.toString()}/${bt2_index}"
+            bt_preprocess = "cp ${index.toString()}/*.bt2 ."
+        } else {
+            bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
         }
         if (params.collapse == true || params.singleEnd == true) {
             """
+            $bt_preprocess
             bowtie2 -x $bt2_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
             """
         } else if (params.collapse == false){
             """
+            $bt_preprocess
             bowtie2 -x $bt2_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
             samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
             samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
@@ -708,16 +716,20 @@ if (params.name3) {
             outfile = name+"_"+params.name3+".aligned.sorted.bam"
             outfile_unalign = name+"_"+params.name3+".unaligned.sorted.bam"
             if (params.index3){
-                bt3_index = "${index.toString()}/${bt3_index}"
+                bt_preprocess = "cp ${index.toString()}/*.bt2 ."
+            }else {
+                bt_preprocess = 'echo nothing_to_preprocess_for_bt_index'
             }
             if (params.collapse == true || params.singleEnd == true) {
                 """
+                $bt_preprocess
                 bowtie2 -x $bt3_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
                 samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
                 samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign
                 """
             } else if (params.collapse == false){
                 """
+                $bt_preprocess
                 bowtie2 -x $bt3_index -1 ${reads[0]} -2 ${reads[1]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
                 samtools view -S -b -F 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile
                 samtools view -S -b -f 4 -@ ${task.cpus} $samfile | samtools sort -@ ${task.cpus} -o $outfile_unalign

--- a/main.nf
+++ b/main.nf
@@ -89,7 +89,7 @@ if (params.help){
 }
 
 // Message for empty run
-if (!params.reads || !params.name1 || !params.name2 || !params.krakendb){
+if ( (!params.reads && !params.readPaths) || !params.name1 || !params.name2 || !params.krakendb || (!params.genome1 && !params.fasta1) || (!params.genome2 && !params.fasta2)){
     log.info"""
     CoproID was launched with missing mandatory arguments.
     Please check your command line and retry.

--- a/main.nf
+++ b/main.nf
@@ -563,6 +563,9 @@ process AlignToGenome1 {
         fstat = name+"_"+params.name1+".stats.txt"
         outfile = name+"_"+params.name1+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name1+".unaligned.sorted.bam"
+        if (params.index1){
+            bt1_index = "${bt1_dir}/${bt1_index}"
+        }
         if (params.collapse == true || params.singleEnd == true) {
             """
             bowtie2 -x $bt1_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
@@ -664,6 +667,9 @@ process AlignToGenome2 {
         fstat = name+"_"+params.name2+".stats.txt"
         outfile = name+"_"+params.name2+".aligned.sorted.bam"
         outfile_unalign = name+"_"+params.name2+".unaligned.sorted.bam"
+        if (params.index2){
+            bt2_index = "${bt2_dir}/${bt2_index}"
+        }
         if (params.collapse == true || params.singleEnd == true) {
             """
             bowtie2 -x $bt2_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat
@@ -701,6 +707,9 @@ if (params.name3) {
             fstat = name+"_"+params.name3+".stats.txt"
             outfile = name+"_"+params.name3+".aligned.sorted.bam"
             outfile_unalign = name+"_"+params.name3+".unaligned.sorted.bam"
+            if (params.index3){
+                bt3_index = "${bt3_dir}/${bt3_index}"
+            }
             if (params.collapse == true || params.singleEnd == true) {
                 """
                 bowtie2 -x $bt3_index -U ${reads[0]} $bowtie_setting --threads ${task.cpus} > $samfile 2> $fstat

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,9 @@ params {
   bowtie = 'very-sensitive'
   krakendb =''
   minKraken = 50
+  endo1 = 0.01
+  endo2 = 0.01
+  endo3 = 0.01
 
   report_template = "$baseDir/templates/coproID_report.ipynb"
   sp_labels = "$baseDir/data/sourcepredict/modern_gut_microbiomes_labels.csv"

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,10 +10,10 @@ params {
   reads = "data/*{1,2}.fastq.gz"
   singleEnd = false
   outdir = './results'
-  params.phred = 33
+  phred = 33
   adna = true
-  genome1 = 'GRCh37'
-  genome2 = 'CanFam3.1'
+  genome1 = ''
+  genome2 = ''
   genome3 = ''
   name1 = 'Homo_sapiens'
   name2 = 'Canis_familiaris'
@@ -34,13 +34,12 @@ params {
   endo1 = 0.01
   endo2 = 0.01
   endo3 = 0.01
-
-  report_template = "$baseDir/templates/coproID_report.ipynb"
   sp_labels = "$baseDir/data/sourcepredict/modern_gut_microbiomes_labels.csv"
   sp_sources = "$baseDir/data/sourcepredict/modern_gut_microbiomes_sources.csv"
   sp_kfold = 5
   sp_pdim = 20
   sp_dim = 2
+  report_template = "$baseDir/templates/coproID_report.ipynb"
   // Boilerplate options
   name = false
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"
@@ -119,7 +118,7 @@ dag {
 manifest {
   name = 'nf-core/coproid'
   author = 'Maxime Borry'
-  homePage = 'https://github.com/nf-core/coproid'
+  homePage = 'https: //github.com/nf-core/coproid'
   description = 'Coprolite Identification'
   mainScript = 'main.nf'
   nextflowVersion = '>=0.32.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -117,7 +117,7 @@ dag {
 manifest {
   name = 'nf-core/coproid'
   author = 'Maxime Borry'
-  homePage = 'https: //github.com/nf-core/coproid'
+  homePage = 'https://github.com/nf-core/coproid'
   description = 'Coprolite Identification'
   mainScript = 'main.nf'
   nextflowVersion = '>=0.32.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,8 +15,8 @@ params {
   genome1 = ''
   genome2 = ''
   genome3 = ''
-  name1 = 'Homo_sapiens'
-  name2 = 'Canis_familiaris'
+  name1 = ''
+  name2 = ''
   name3 = ''
   index1 = ''
   index2 = ''
@@ -39,7 +39,6 @@ params {
   sp_kfold = 5
   sp_pdim = 20
   sp_dim = 2
-  report_template = "$baseDir/templates/coproID_report.ipynb"
   // Boilerplate options
   name = false
   multiqc_config = "$baseDir/assets/multiqc_config.yaml"

--- a/templates/coproID_report.ipynb
+++ b/templates/coproID_report.ipynb
@@ -1378,7 +1378,7 @@
     "fwd_ext = \".5pCtoT_freq.txt\"\n",
     "rev_ext = \".3pGtoA_freq.txt\"\n",
     "samples = list(set([i.split(\"_otu_\")[0] for i in allplots]))\n",
-    "species = list(set([\"_\".join(\".\".join(i.split(\".\")[0:-1]).split(\"_otu_\")[1:]) for i in allplots]))"
+    "species = list(set([\"_\".join(\".\".join(i.split(\".\")[0:-2]).split(\"_otu_\")[1:]) for i in allplots]))"
    ]
   },
   {

--- a/templates/coproID_report.ipynb
+++ b/templates/coproID_report.ipynb
@@ -1378,7 +1378,7 @@
     "fwd_ext = \".5pCtoT_freq.txt\"\n",
     "rev_ext = \".3pGtoA_freq.txt\"\n",
     "samples = list(set([i.split(\"_otu_\")[0] for i in allplots]))\n",
-    "species = list(set([\"_\".join(i.split(\".\")[0].split(\"_otu_\")[1:]) for i in allplots]))"
+    "species = list(set([\"_\".join(\".\".join(i.split(\".\")[0:-1]).split(\"_otu_\")[1:]) for i in allplots]))"
    ]
   },
   {

--- a/templates/coproID_report.ipynb
+++ b/templates/coproID_report.ipynb
@@ -88,7 +88,7 @@
     "    labels = list(set(source.data['labels']))\n",
     "    color_map = factor_cmap(field_name='labels', palette=Set1[9], factors=labels)\n",
     "    p = figure(tools=TOOLS)\n",
-    "    p.scatter(x = 'PC1', y='PC2', color=color_map, alpha = 0.6, size = 6, source=d)\n",
+    "    p.scatter(x = 'PC1', y='PC2', color=color_map, alpha = 0.6, size = 6, legend='labels', source=d)\n",
     "    hover = HoverTool()\n",
     "    hover.tooltips = [(\"Organism\", \"@labels\"),('Sample',\"@name\")]\n",
     "    p.add_tools(hover)\n",


### PR DESCRIPTION
1. Adding endogenous DNA content in `bin/normalizedReadCount`
2. Transfering arguments to `main.nf`
3. Updating the doc for endogenous DNA content 
4. Some reformatting of very long lines in `main.nf` and `bin/normalizedReadCount`
5. Add help message for runs with missing mandatory arguments
6. Fix bowtie and kraken indices channels
7. Various tests for singularity
8. Improving and fixing coproID report generation
