### PR TITLE
Update dockerfile for Numba and ete3 write directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,8 @@ RUN conda env export --name nf-core-coproid-1.1dev > nf-core-coproid-1.1dev.yml
 ENV PATH /opt/conda/envs/nf-core-coproid-1.1dev/bin:$PATH
 
 # Dump the details of the installed packages to a file for posterity
+RUN conda env export --name nf-core-coproid-1.1dev > nf-core-coproid-1.1dev.yml
+
+# Numba cache dir patch
+ENV NUMBA_CACHE_DIR /tmp
+ENV HOME /tmp


### PR DESCRIPTION
To rebuild docker container in preparation for #27 

- [`NUMBA_CACHE_DIR`](https://numba.pydata.org/numba-doc/dev/reference/envvars.html#envvar-NUMBA_CACHE_DIR) environment variable needs to be set to a writable path.

- `HOME` needs to be writable for ete3 for downloading NCBI taxonomy files.
